### PR TITLE
Upgrade excon >= 1.5.0 to address CVE-2026-54171 (breaking: drops Ruby < 3.1)

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby 3.1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 3.1
 
     - name: Publish to GPR
       run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v2

--- a/postcodes_io.gemspec
+++ b/postcodes_io.gemspec
@@ -17,11 +17,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = ">= 3.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "webmock"
 
-  spec.add_runtime_dependency "excon", "~> 0.39"
+  spec.add_runtime_dependency "excon", ">= 1.5.0"
 end


### PR DESCRIPTION
excon 1.5.0 fixes GHSA-48rx-c7pg-q66r (medium — header redaction on redirects) but requires Ruby >= 3.1. This drops support for Ruby 2.6, 2.7, and 3.0, all of which are end-of-life.

Changes:
- gemspec: excon ~> 0.39 → >= 1.5.0, required_ruby_version >= 3.1
- CI matrix: 2.6/2.7/3.0 → 3.1/3.2/3.3
- gem-push workflow: Ruby 2.6 → 3.1