### PR TITLE
[BREAKING] Upgrade excon >= 1.5.0 to address CVE-2026-54171

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -13,7 +13,7 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up Ruby 3.1
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+    - name: Set up Ruby 3.1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 3.1
 
     - name: Publish to GPR
       run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,10 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
         ruby-version: ['3.1', '3.2', '3.3']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v2

--- a/postcodes_io.gemspec
+++ b/postcodes_io.gemspec
@@ -17,11 +17,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = ">= 3.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "webmock"
 
-  spec.add_runtime_dependency "excon", "~> 0.39"
+  spec.add_runtime_dependency "excon", ">= 1.5.0"
 end


### PR DESCRIPTION
> **Breaking change:** This drops support for Ruby < 3.1

  ## Summary
  - Bumps excon from `~> 0.39` to `>= 1.5.0` to fix GHSA-48rx-c7pg-q66r
    (medium - header redaction on cross-host redirects)
  - excon 1.5.0 requires Ruby >= 3.1; all dropped versions are end-of-life
  - Updates CI matrix and publish workflow to Ruby 3.1/3.2/3.3
  - Bumps `actions/checkout` from v2 (Node 12) to v7 and `ruby/setup-ruby`
    to `@v1` to fix Node deprecation failures on current runners
